### PR TITLE
фикс исправление конфигурации сервиса "ExecuteJavascriptMiddleware"

### DIFF
--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -103,6 +103,12 @@ return static function (ContainerConfigurator $container): void {
             service('event_dispatcher'),
         ])
     ;
+	$services
+		->set(\RoachPHP\Downloader\Middleware\ExecuteJavascriptMiddleware::class)
+		->args([
+			service('roach_php.logger'),
+		])
+	;
     $services->set(\RoachPHP\Downloader\Middleware\CookieMiddleware::class);
     $services
         ->set(\RoachPHP\Downloader\Middleware\RequestDeduplicationMiddleware::class)


### PR DESCRIPTION
Без данного конфига, невозможно подключить встроенный middleware для отрисовки страницы через headless Chrome